### PR TITLE
Fix compatibility issues and deprecations

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -18,7 +18,7 @@ def fetchcube(catalog_name, cube_name):
     catalog = get_catalog(catalog_name)
     cube_data = fetch_cube(catalog, cube_name)
     if cube_data is None:
-        log.warn("Could not fetch: %s", cube_name)
+        log.warning("Could not fetch: %s", cube_name)
     else:
         store_cube_raw(catalog_name, cube_name, cube_data)
 
@@ -33,7 +33,7 @@ def fetch(catalog_name, update=False):
             try:
                 cube_data = fetch_cube(catalog, cube_name)
                 if cube_data is None:
-                    log.warn("Could not fetch: %s", cube_name)
+                    log.warning("Could not fetch: %s", cube_name)
                 else:
                     store_cube_raw(catalog_name, cube_name, cube_data)
             except Exception as e:

--- a/manage.py
+++ b/manage.py
@@ -1,12 +1,10 @@
 import logging
-from flask.ext.script import Manager
+from flask_script import Manager
 
-from regenesis.core import app, get_catalog
-from regenesis.export import JSONEncoder
+from regenesis.core import get_catalog
 from regenesis.cube import Cube
 from regenesis.web import app
-from regenesis.storage import store_cube_raw, load_cube_raw, \
-    dump_cube_json, exists_raw
+from regenesis.storage import store_cube_raw, load_cube_raw, exists_raw
 from regenesis.retrieve import fetch_index, fetch_cube
 from regenesis.database import load_cube
 

--- a/regenesis/analysis.py
+++ b/regenesis/analysis.py
@@ -1,7 +1,5 @@
 from pprint import pprint 
 
-from regenesis.core import app, engine
-from regenesis.database import statistic_table, cube_table, reference_table
 from regenesis.queries import get_cubes, get_dimensions
 
 def find_denormalized():

--- a/regenesis/cube.py
+++ b/regenesis/cube.py
@@ -12,7 +12,6 @@ FIELD_TYPES = {
   'regiostat': parse_bool,
   'secret_values': parse_bool,
   'spr_tmp': parse_bool,
-  'regiostat': parse_bool,
   'trans_flag_2': parse_bool,
   'meta_variable': parse_bool,
   'summable': parse_bool,

--- a/regenesis/database.py
+++ b/regenesis/database.py
@@ -2,7 +2,7 @@ import logging
 
 from sqlalchemy.types import BigInteger
 
-from regenesis.core import app, engine
+from regenesis.core import engine
 
 log = logging.getLogger(__name__)
 

--- a/regenesis/freeze.py
+++ b/regenesis/freeze.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from dataset import freeze
+from datafreeze import freeze
 
 from regenesis.queries import get_all_statistics, get_all_dimensions
 from regenesis.queries import get_cubes, query_cube

--- a/regenesis/freeze.py
+++ b/regenesis/freeze.py
@@ -5,15 +5,17 @@ from dataset import freeze
 from regenesis.queries import get_all_statistics, get_all_dimensions
 from regenesis.queries import get_cubes, query_cube
 from regenesis.database import value_table
-from regenesis.util import slugify
+from slugify import slugify
 from regenesis.web import app
 from regenesis.core import engine
 
 client = app.test_client()
 
+
 def get_output_dir():
     return os.path.join( app.root_path, '..', 'build')
     #return '/Users/fl/tmp/regenesis'
+
 
 def freeze_request(req_path):
     print("Freezing %s..." % req_path)
@@ -64,6 +66,7 @@ def freeze_data():
             print([fn])
             freeze(engine.query(q), prefix=prefix, filename=fn)
             #print cube['cube_name']
+
 
 if __name__ == '__main__':
     freeze_data()

--- a/regenesis/projection.py
+++ b/regenesis/projection.py
@@ -1,6 +1,7 @@
 from regenesis.queries import get_cubes, query_cube
 from regenesis.core import engine
-from regenesis.util import slugify
+from slugify import slugify
+
 
 def make_views():
     for cube in get_cubes():
@@ -13,6 +14,7 @@ def make_views():
         q = 'CREATE VIEW ' + slug + ' AS ' + str(q)
         engine.query(q, **params)
         print([slug, q])
+
 
 if __name__ == '__main__':
     make_views()

--- a/regenesis/queries.py
+++ b/regenesis/queries.py
@@ -1,6 +1,6 @@
-from sqlalchemy import func, select, and_
+from sqlalchemy import select, and_
 from sqlalchemy.sql.expression import bindparam
-from regenesis.core import engine, app
+from regenesis.core import engine
 
 from regenesis.database import cube_table, value_table, statistic_table
 from regenesis.database import dimension_table, reference_table, get_fact_table

--- a/regenesis/queries.py
+++ b/regenesis/queries.py
@@ -33,11 +33,14 @@ def get_dimensions(cube_name):
     res = engine.query(q)
     return list(res)
 
+
 def get_all_dimensions():
     return list(dimension_table)
 
+
 def get_all_statistics():
     return list(statistic_table)
+
 
 def query_cube(cube_name, readable=True):
     cube = get_cube(cube_name)

--- a/regenesis/storage.py
+++ b/regenesis/storage.py
@@ -1,6 +1,7 @@
 import os
 import json
 from regenesis.core import app
+from regenesis.export import JSONEncoder
 
 def cube_path(catalog, cube_name, ext='raw'):
     return os.path.join(

--- a/regenesis/storage.py
+++ b/regenesis/storage.py
@@ -3,23 +3,27 @@ import json
 from regenesis.core import app
 from regenesis.export import JSONEncoder
 
+
 def cube_path(catalog, cube_name, ext='raw'):
     return os.path.join(
-            app.config.get('DATA_DIRECTORY'),
-            catalog,
-            cube_name + '.' + ext
-            )
+      app.config.get('DATA_DIRECTORY'),
+      catalog,
+      cube_name + '.' + ext
+    )
+
 
 def exists_raw(catalog, cube_name):
     return os.path.isfile(cube_path(catalog, cube_name))
 
+
 def store_cube_raw(catalog, cube_name, cube_data):
     path = cube_path(catalog, cube_name)
     if not os.path.isdir(os.path.dirname(path)):
-        os.makedirs(os.path.dirname(path))
+      os.makedirs(os.path.dirname(path))
     fh = open(path, 'wb')
     fh.write(cube_data.encode('utf-8'))
     fh.close()
+
 
 def load_cube_raw(catalog, cube_name):
     fh = open(cube_path(catalog, cube_name), 'rb')
@@ -27,8 +31,8 @@ def load_cube_raw(catalog, cube_name):
     fh.close()
     return data
 
+
 def dump_cube_json(catalog, cube):
     fh = open(cube_path(catalog, cube.name, 'json'), 'wb')
     json.dump(cube, fh, cls=JSONEncoder, indent=2)
     fh.close()
-

--- a/regenesis/web.py
+++ b/regenesis/web.py
@@ -1,6 +1,6 @@
 #coding: utf-8
-from flask import render_template, Response, request
-from flask import session, redirect, flash, Markup, url_for
+from flask import render_template, Response
+from flask import Markup
 
 from regenesis.core import app
 from slugify import slugify as _slugify

--- a/regenesis/web.py
+++ b/regenesis/web.py
@@ -62,7 +62,6 @@ def page_api():
     return render_template('api.html')
 
 
-
 @app.route('/faq.html')
 def page_faq():
     return render_template('faq.html')

--- a/regenesis/web.py
+++ b/regenesis/web.py
@@ -3,7 +3,7 @@ from flask import render_template, Response, request
 from flask import session, redirect, flash, Markup, url_for
 
 from regenesis.core import app
-from regenesis.util import slugify as _slugify
+from slugify import slugify as _slugify
 from regenesis.views.util import dimension_type_text as _dimension_type_text
 from regenesis.views.dimension import blueprint as dimension_blueprint
 from regenesis.views.statistic import blueprint as statistic_blueprint

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ sqlalchemy
 slugify
 PyYAML>=3.10
 requests>=1.1.0
-dataset
+datafreeze
 lxml
 argparse>=1.2.1
 Flask>=0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+sqlalchemy
 slugify
 PyYAML>=3.10
 requests>=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+slugify
 PyYAML>=3.10
 requests>=1.1.0
 dataset


### PR DESCRIPTION
This PR fixes compatibility issues and deprecations with Python 3 and current versions of package dependencies:

- Import slugify directly from slugify package
- Import Flask Manager from flask_script package
- replace deprecated log.warn with log.warning
- Import freeze from datafreeze package
- Fix JSONEncoder import
- Add sqlalchemy, slugify and datafreeze dependencies
- Fix formatting
- Cleanup unused imports