### PR TITLE
Fixes for regenesis freeze command

### DIFF
--- a/regenesis/freeze.py
+++ b/regenesis/freeze.py
@@ -23,7 +23,7 @@ def freeze_request(req_path):
     dirname = os.path.dirname(path)
     if not os.path.exists(dirname):
         os.makedirs(dirname)
-    fh = open(path, 'w')
+    fh = open(path, 'wb')
     res = client.get(req_path)
     fh.write(res.data)
     fh.close()

--- a/regenesis/views/statistic.py
+++ b/regenesis/views/statistic.py
@@ -11,11 +11,11 @@ from regenesis.views.util import parse_description
 blueprint = Blueprint('statistic', __name__)
 
 ADM_RANKS = {
-    'gemein': 1,
-    'kreise': 2,
-    'regbez': 3,
-    'dland': 4,
-    'dinsg': 5
+    'GEMEIN': 1,
+    'KREISE': 2,
+    'REGBEZ': 3,
+    'DLAND': 4,
+    'DINSG': 5
 }
 
 def make_keywords(titles):


### PR DESCRIPTION
Additional fixes to get the freeze command working again:

- Open output file in binary mode
- use upper-case keys for statistical regions lookup